### PR TITLE
DEV-356  Add send feedback logic

### DIFF
--- a/lib/smess/output.rb
+++ b/lib/smess/output.rb
@@ -19,5 +19,9 @@ module Smess
       raise NotImplementedError.new("You must define deliver in your Smess output class")
     end
 
+    def send_feedback(_message_sid)
+      nil
+    end
+
   end
 end

--- a/lib/smess/outputs/auto.rb
+++ b/lib/smess/outputs/auto.rb
@@ -11,6 +11,11 @@ module Smess
       out.deliver.merge({sent_with: output_name})
     end
 
+    def send_feedback(message_sid)
+      out = output_for sms.to
+      out.send_feedback(message_sid)
+    end
+
     def get_output_name_for_msisdn(msisdn)
       3.downto(0).each do |index|
         return Smess.config.output_by_country_code[msisdn[0..index]] if Smess.config.output_by_country_code.key? msisdn[0..index]

--- a/lib/smess/outputs/twilio.rb
+++ b/lib/smess/outputs/twilio.rb
@@ -10,12 +10,17 @@ module Smess
     end
 
     attr_accessor :sid, :auth_token, :from, :messaging_service_sid, :callback_url
+
     def validate_config
       @sid = config.fetch(:sid)
       @auth_token = config.fetch(:auth_token)
       @from = config.fetch(:from, nil)
       @messaging_service_sid = config.fetch(:messaging_service_sid, nil)
       @callback_url = config.fetch(:callback_url)
+    end
+
+    def send_feedback(message_sid)
+      @client.messages(message_sid).feedback.create(outcome: "confirmed")
     end
 
     def deliver
@@ -31,7 +36,7 @@ module Smess
     end
 
     def split_parts
-      Smess.separate_sms(sms.message).reject {|s| s.empty? }
+      Smess.separate_sms(sms.message).reject { |s| s.empty? }
     end
 
     def send_one_sms(message)
@@ -43,9 +48,9 @@ module Smess
           provide_feedback: true
         }
         if messaging_service_sid.present?
-          opts[:messaging_service_sid] =  messaging_service_sid
+          opts[:messaging_service_sid] = messaging_service_sid
         else
-          opts[:from] =  from
+          opts[:from] = from
         end
         response = create_client_message(opts)
         result = normal_result(response)

--- a/lib/smess/outputs/twilio.rb
+++ b/lib/smess/outputs/twilio.rb
@@ -20,7 +20,7 @@ module Smess
     end
 
     def send_feedback(message_sid)
-      @client.messages(message_sid).feedback.create(outcome: "confirmed")
+      client.messages(message_sid).feedback.create(outcome: "confirmed")
     end
 
     def deliver

--- a/lib/smess/sms.rb
+++ b/lib/smess/sms.rb
@@ -21,5 +21,12 @@ module Smess
       results[:response_code] == "0"
     end
 
+    def send_feedback(to, message_sid)
+      out = Smess.named_output_instance(output)
+      @to = to
+      output.sms = self
+      out.send_feedback(message_sid)
+    end
+
   end
 end

--- a/lib/smess/sms.rb
+++ b/lib/smess/sms.rb
@@ -24,7 +24,7 @@ module Smess
     def send_feedback(to, message_sid)
       out = Smess.named_output_instance(output)
       @to = to
-      output.sms = self
+      out.sms = self
       out.send_feedback(message_sid)
     end
 


### PR DESCRIPTION
I have done an end-to-end test using the code, and I can successfully submit the feedback, receiving back a `<Twilio.Api.V2010.FeedbackInstance>` object with `message id`, `outcome`, etc.

In the case where the message id I send is invalid, we get:
```
Unable to submit sms feedback to twilio: [HTTP 404] 20404 : Unable to create record
The requested resource /2010-04-01/Accounts/AC3c97bfde30d4955d68d740049c3377e8/Messages/test/Feedback.json was not found
https://www.twilio.com/docs/errors/20404
```
as expected